### PR TITLE
Add recipe for evil-smart-input-source

### DIFF
--- a/recipes/evil-smart-input-source
+++ b/recipes/evil-smart-input-source
@@ -1,0 +1,3 @@
+(evil-smart-input-source
+  :fetcher github
+  :repo "laishulu/evil-smart-input-source")


### PR DESCRIPTION
### Brief summary of what the package does

Switch input source for Emacs/evil smartly.

### Direct link to the package repository

https://github.com/laishulu/evil-smart-input-source

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I have confirmed some of these without doing them
